### PR TITLE
 Changed MSI property names after performed changes in WaykNow MSI

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -429,17 +429,17 @@ CseInstallResult CseInstall_SetInstallDirectory(CseInstall* ctx, const char* dir
 
 CseInstallResult CseInstall_EnableLaunchWaykNowAfterInstall(CseInstall* ctx)
 {
-	return CseInstall_SetMsiOption(ctx, "START_AFTER_INSTALL", "1");
+	return CseInstall_SetMsiOption(ctx, "SUPPRESSLAUNCH", "");
 }
 
 CseInstallResult CseInstall_DisableDesktopShortcut(CseInstall* ctx)
 {
-	return CseInstall_SetMsiOption(ctx, "DISABLE_DESKTOP_SHORTCUT", "1");
+	return CseInstall_SetMsiOption(ctx, "INSTALLDESKTOPSHORTCUT", "");
 }
 
 CseInstallResult CseInstall_DisableStartMenuShortcut(CseInstall* ctx)
 {
-	return CseInstall_SetMsiOption(ctx, "DISABLE_START_MENU_SHORTCUT", "1");
+	return CseInstall_SetMsiOption(ctx, "INSTALLSTARTMENUSHORTCUT", "");
 }
 
 CseInstallResult CseInstall_SetBrandingFile(CseInstall* ctx, const char* brandingFilePath)

--- a/wayk-cse-patcher/src/artifacts_bundle.rs
+++ b/wayk-cse-patcher/src/artifacts_bundle.rs
@@ -34,7 +34,7 @@ impl ArtifactsBundle {
         &mut self,
         writer: &mut W,
     ) -> ArtifactsBundleResult<u64> {
-        const WAYK_NOW_FILE_NAME: &str = "WaykNow.exe";
+        const WAYK_NOW_FILE_NAME: &str = "WaykAgent.exe";
 
         let mut compressed = self
             .archive

--- a/wayk-cse-patcher/src/download.rs
+++ b/wayk-cse-patcher/src/download.rs
@@ -34,27 +34,21 @@ impl Error {
 
 pub type DownloadResult<T> = Result<T, Error>;
 
-fn construct_package_url(
-    bitness: Bitness,
-    version: NowVersion,
-    extension: &str,
-) -> DownloadResult<Url> {
-    let url = Url::parse(&format!(
-        "https://cdn.devolutions.net/download/Wayk/{0}/WaykNow-{1}-{0}.{2}",
-        version.as_quad(),
-        bitness,
-        extension
-    ))?;
-
-    Ok(url)
-}
 
 fn construct_msi_url(bitness: Bitness, version: NowVersion) -> DownloadResult<Url> {
-    construct_package_url(bitness, version, "msi")
+    Ok(Url::parse(&format!(
+        "https://cdn.devolutions.net/download/Wayk/{0}/WaykAgent-{1}-{0}.msi",
+        version.as_quad(),
+        bitness
+    ))?)
 }
 
 fn construct_zip_url(bitness: Bitness, version: NowVersion) -> DownloadResult<Url> {
-    construct_package_url(bitness, version, "zip")
+    Ok(Url::parse(&format!(
+        "https://cdn.devolutions.net/download/Wayk/{0}/WaykNow-{1}-{0}.zip",
+        version.as_quad(),
+        bitness
+    ))?)
 }
 
 fn download_artifact(destination: &Path, url: &Url) -> DownloadResult<()> {


### PR DESCRIPTION
Fixed MSI arguments generation after removing redundant MSI properties from the WaykNow MSI.