### PR TITLE
Windows 7 compatibility fixes and true silent execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ target_include_directories(
 	"${CMAKE_CURRENT_LIST_DIR}/include"
 	"${CMAKE_CURRENT_BINARY_DIR}")
 
-add_executable(${MODULE_NAME} ${${MODULE_PREFIX}_SOURCES} ${${MODULE_PREFIX}_RESOURCES})
+add_executable(${MODULE_NAME} WIN32 ${${MODULE_PREFIX}_SOURCES} ${${MODULE_PREFIX}_RESOURCES})
 target_link_libraries(${MODULE_NAME} PRIVATE ${MODULE_NAME}-lib)
 set_target_properties(${MODULE_NAME} PROPERTIES OUTPUT_NAME "${OUTPUT_NAME}")
 

--- a/include/cse/bundle.h
+++ b/include/cse/bundle.h
@@ -23,11 +23,6 @@ typedef struct waykcse_bundle WaykCseBundle;
 WaykCseBundle* WaykCseBundle_Open();
 void WaykCseBundle_Close(WaykCseBundle* ctx);
 
-
-WaykCseBundleStatus WaykCseBundle_ExtractWaykNowExecutable(
-	WaykCseBundle* ctx,
-	WaykBinariesBitness bitness,
-	const char* targetFolder);
 WaykCseBundleStatus WaykCseBundle_ExtractWaykNowInstaller(
 	WaykCseBundle* ctx,
 	WaykBinariesBitness bitness,
@@ -46,7 +41,6 @@ const char* GetBrandingFileName();
 const char* GetPowerShellInitScriptFileName();
 const char* GetJsonOptionsFileName();
 const char* GetInstallerFileName(WaykBinariesBitness bitness);
-const char* GetWaykNowBinaryFileName(WaykBinariesBitness bitness);
 
 
 #endif //WAYKCSE_BUNDLE_H

--- a/include/cse/install.h
+++ b/include/cse/install.h
@@ -1,6 +1,8 @@
 #ifndef WAYKCSE_INSTALL_H
 #define WAYKCSE_INSTALL_H
 
+#include <stdbool.h>
+
 typedef enum
 {
 	CSE_INSTALL_OK,
@@ -14,14 +16,13 @@ typedef enum
 
 typedef struct cse_install CseInstall;
 
-CseInstall* CseInstall_WithLocalMsi(const char* waykNowExecutable, const char* msiPath);
-CseInstall* CseInstall_WithMsiDownload(const char* waykNowExecutable);
+CseInstall* CseInstall_WithLocalMsi(const char* msiPath);
 void CseInstall_Free(CseInstall* ctx);
 
 CseInstallResult CseInstall_SetEnrollmentOptions(CseInstall* ctx, const char* url, const char* token);
 CseInstallResult CseInstall_SetConfigOption(CseInstall* ctx, const char* key, const char* value);
 CseInstallResult CseInstall_SetInstallDirectory(CseInstall* ctx, const char* dir);
-CseInstallResult CseInstall_SetQuiet(CseInstall* ctx);
+CseInstallResult CseInstall_SetQuiet(CseInstall* ctx, bool quiet);
 CseInstallResult CseInstall_DisableDesktopShortcut(CseInstall* ctx);
 CseInstallResult CseInstall_DisableStartMenuShortcut(CseInstall* ctx);
 CseInstallResult CseInstall_DisableSuppressLaunch(CseInstall* ctx);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -13,11 +13,6 @@
 #define INSTALLER_FILE_NAME_X86 "Installer_x86.msi"
 #define INSTALLER_FILE_NAME_X64 "Installer_x64.msi"
 
-// NOTE WaykNow executable should not have "WaykNow" in its name, because
-// in this case it will be killed by the MSI installer
-#define WAYK_NOW_BINARY_FILE_NAME_X86 "Bootstrapper_x86.exe"
-#define WAYK_NOW_BINARY_FILE_NAME_X64 "Bootstrapper_x64.exe"
-
 #define JSON_OPTIONS_FILE_NAME "options.json"
 
 struct waykcse_bundle
@@ -104,9 +99,11 @@ static WaykCseBundleStatus WaykCseBundle_ExtractSingleFile(
 	LzPathCchAppend(outputPath, sizeof(outputPath), targetFolder);
 	LzPathCchAppend(outputPath, sizeof(outputPath), fileName);
 
-	if (LzArchive_ExtractFile(ctx->archiveHandle, -1, fileName, outputPath) != LZ_OK)
+	int rv = LzArchive_ExtractFile(ctx->archiveHandle, -1, fileName, outputPath);
+	
+	if (rv != LZ_OK)
 	{
-		CSE_LOG_ERROR("Failed to extract %s from the bundle\n", fileName);
+		CSE_LOG_ERROR("Failed to extract %s from the bundle: %d %s\n", fileName, rv, outputPath);
 		return WAYK_CSE_BUNDLE_MISSING_PACKAGE;
 	}
 
@@ -118,14 +115,6 @@ WaykCseBundleStatus WaykCseBundle_ExtractBrandingZip(
 	const char* targetFolder)
 {
 	return WaykCseBundle_ExtractSingleFile(ctx, targetFolder, GetBrandingFileName());
-}
-
-WaykCseBundleStatus WaykCseBundle_ExtractWaykNowExecutable(
-	WaykCseBundle* ctx,
-	WaykBinariesBitness bitness,
-	const char* targetFolder)
-{
-	return WaykCseBundle_ExtractSingleFile(ctx, targetFolder, GetWaykNowBinaryFileName(bitness));
 }
 
 WaykCseBundleStatus WaykCseBundle_ExtractWaykNowInstaller(
@@ -163,13 +152,6 @@ const char* GetPowerShellInitScriptFileName()
 const char* GetJsonOptionsFileName()
 {
 	return JSON_OPTIONS_FILE_NAME;
-}
-
-const char* GetWaykNowBinaryFileName(WaykBinariesBitness bitness)
-{
-	return (bitness == WAYK_BINARIES_BITNESS_X86)
-		? WAYK_NOW_BINARY_FILE_NAME_X86
-		: WAYK_NOW_BINARY_FILE_NAME_X64;
 }
 
 const char* GetInstallerFileName(WaykBinariesBitness bitness)

--- a/src/cse_utils.c
+++ b/src/cse_utils.c
@@ -522,7 +522,8 @@ finalization:
 	return status;
 }
 
-int SetWaykNowExePath(char* pathBuffer, int pathBufferSize){
+int SetWaykNowExePath(char* pathBuffer, int pathBufferSize)
+{
 	char path[LZ_MAX_PATH];
 	
 	WIN32_FIND_DATAW fd;

--- a/src/download.c
+++ b/src/download.c
@@ -119,7 +119,7 @@ CseDownloadResult CseDownload_DownloadMsi(WaykBinariesBitness bitness, const cha
 	CSE_LOG_INFO("Downloading MSI from %s", msiUrl);
 
 	LzHttp_SetRecvTimeout(http, 600 * 1000);
-	status = LzHttp_Get(http, msiUrl, CseDownload_OnWriteFile, fp, error);
+	status = LzHttp_Get(http, msiUrl, CseDownload_OnWriteFile, fp, &error);
 
 	if (status != LZ_OK)
 	{

--- a/src/log.c
+++ b/src/log.c
@@ -14,7 +14,6 @@ typedef struct
 
 typedef void (*log_LogFn)(LogMessageContext *ev);
 
-
 static struct
 {
 	CseLogLevel level;
@@ -22,9 +21,7 @@ static struct
 	FILE* outputFile;
 } CseLog;
 
-
 static const char *level_strings[] = {"TRACE", "DEBUG", "INFO", "WARN", "ERROR"};
-
 
 static void WriteLogInternal(LogMessageContext* ctx)
 {

--- a/tests/cse_install.c
+++ b/tests/cse_install.c
@@ -6,12 +6,12 @@
 
 int all_available_options()
 {
-	CseInstall* install = CseInstall_WithLocalMsi("C:\\wayk.exe", "C:\\installer.msi");
+	CseInstall* install = CseInstall_WithLocalMsi( "C:\\installer.msi");
 	if (!install)
 		return 1;
 	if (CseInstall_SetEnrollmentOptions(install,"http://my-url.com","1234567890") != CSE_INSTALL_OK)
 		return 2;
-	if (CseInstall_SetConfigOption(install, "analyticsEnabled", "false") != CSE_INSTALL_OK)
+	if (CseInstall_SetConfigOption(install, "AnalyticsEnabled", "false") != CSE_INSTALL_OK)
 		return 3;
 	if (CseInstall_SetInstallDirectory(install, "D:\\wayk_install") != CSE_INSTALL_OK)
 		return 4;
@@ -21,11 +21,11 @@ int all_available_options()
 		return 6;
 
 	const char* expected =
-		"\"C:\\wayk.exe\" install-local-package \"C:\\installer.msi\" "
-		"\"ENROLL_DEN_URL=\\\"http://my-url.com\\\"\" \"ENROLL_TOKEN_ID=\\\"1234567890\\\"\" "
-		"\"CONFIG_ANALYTICS_ENABLED=\\\"false\\\"\" \"INSTALLDIR=\\\"D:\\wayk_install\\\"\" "
-		"\"INSTALLDESKTOPSHORTCUT=\\\"0\\\"\" "
-		"\"INSTALLSTARTMENUSHORTCUT=\\\"0\\\"\"";
+		"msiexec /i \"C:\\installer.msi\" "
+		"ENROLL_DEN_URL=\"http://my-url.com\" ENROLL_TOKEN_ID=\"1234567890\" "
+		"CONFIG_ANALYTICS_ENABLED=\"false\" INSTALLDIR=\"D:\\wayk_install\" "
+		"INSTALLDESKTOPSHORTCUT=\"\" "
+		"INSTALLSTARTMENUSHORTCUT=\"\"";
 
 	const char* actual = CseInstall_GetCli(install);
 
@@ -36,30 +36,9 @@ int all_available_options()
 	return 0;
 }
 
-int download_msi()
-{
-	CseInstall* install = CseInstall_WithMsiDownload("C:\\wayk.exe");
-	if (!install)
-		return 1;
-
-	if (CseInstall_SetEnrollmentOptions(install,"http://my-url.com","1234567890") != CSE_INSTALL_OK)
-		return 2;
-
-	const char* expected =
-		"\"C:\\wayk.exe\" install \"ENROLL_DEN_URL=\\\"http://my-url.com\\\"\" "
-		"\"ENROLL_TOKEN_ID=\\\"1234567890\\\"\"";
-
-	const char* actual = CseInstall_GetCli(install);
-
-	if (strcmp(actual, expected) != 0)
-		return 3;
-
-	return 0;
-}
-
 int quoted_argument_escape()
 {
-	CseInstall* install = CseInstall_WithMsiDownload("C:\\wayk.exe");
+	CseInstall* install = CseInstall_WithLocalMsi( "C:\\installer.msi");
 	if (!install)
 		return 1;
 
@@ -67,7 +46,8 @@ int quoted_argument_escape()
 		return 2;
 
 	const char* expected =
-		"\"C:\\wayk.exe\" install \"CONFIG_PERSONAL_PASSWORD=\\\"qwe\\\\\\\"rty\\\"\"";
+		"msiexec /i \"C:\\installer.msi\" "
+		"CONFIG_PERSONAL_PASSWORD=\"qwe\\\\\\\"rty\"";
 
 	const char* actual = CseInstall_GetCli(install);
 
@@ -80,7 +60,6 @@ int quoted_argument_escape()
 int main()
 {
 	assert_test_succeeded(all_available_options());
-	assert_test_succeeded(download_msi());
 	assert_test_succeeded(quoted_argument_escape());
 	return 0;
 }

--- a/wayk-cse-patcher/Cargo.toml
+++ b/wayk-cse-patcher/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "wayk-cse-patcher"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Vladislav Nikonov <nikonov.vladislav@apriorit.com>"]
 edition = "2018"
 description = "WaykNow custom standalone executable (CSE) patcher"
 build = "build.rs"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
 cmake = "0.1"

--- a/wayk-cse-patcher/src/bundle.rs
+++ b/wayk-cse-patcher/src/bundle.rs
@@ -41,7 +41,6 @@ pub enum Error {
 type BundlePackerResult<T> = Result<T, Error>;
 
 pub enum BundlePackageType {
-    WaykBinaries { bitness: Bitness },
     InstallationMsi { bitness: Bitness },
     BrandingZip,
     CustomInitializationScript,
@@ -68,16 +67,6 @@ impl BundlePacker {
 
         for (package_type, package_path) in &self.packages {
             match package_type {
-                BundlePackageType::WaykBinaries { bitness } => {
-                    let mut artifacts = ArtifactsBundle::open(&package_path)?;
-
-                    let executable_path = bundle_directory
-                        .path()
-                        .join(format!("Bootstrapper_{}.exe", bitness));
-
-                    let mut file = File::create(executable_path)?;
-                    artifacts.extract_wayk_now_binary(&mut file)?;
-                }
                 BundlePackageType::InstallationMsi { bitness } => {
                     fs::copy(
                         package_path,
@@ -160,18 +149,6 @@ mod tests {
             Path::new("tests/data/fake_init_script.ps1"),
         );
         packer.add_bundle_package(
-            BundlePackageType::WaykBinaries {
-                bitness: Bitness::X64,
-            },
-            Path::new("tests/data/wayk_now_mock_binaries.zip"),
-        );
-        packer.add_bundle_package(
-            BundlePackageType::WaykBinaries {
-                bitness: Bitness::X86,
-            },
-            Path::new("tests/data/wayk_now_mock_binaries.zip"),
-        );
-        packer.add_bundle_package(
             BundlePackageType::CseOptions,
             Path::new("tests/data/options.json"),
         );
@@ -197,8 +174,6 @@ mod tests {
             .unwrap();
 
         let stdout = std::str::from_utf8(&output.stdout).unwrap().to_string();
-        assert!(stdout.contains("Bootstrapper_x64.exe"));
-        assert!(stdout.contains("Bootstrapper_x86.exe"));
         assert!(stdout.contains("Installer_x86.msi"));
         assert!(stdout.contains("Installer_x64.msi"));
         assert!(stdout.contains("branding.zip"));

--- a/wayk-cse-patcher/src/patcher.rs
+++ b/wayk-cse-patcher/src/patcher.rs
@@ -27,7 +27,7 @@ impl WaykCsePatcher {
 
         let mut cse_binary_reader: &[u8] = cse_binary.as_ref();
 
-        let mut cse_target_file = File::create(path).context("Failed co create output file")?;
+        let mut cse_target_file = File::create(path).context("Failed to create output file")?;
         io::copy(&mut cse_binary_reader, &mut cse_target_file)
             .context("Failed to extract original cse file")?;
 
@@ -63,20 +63,7 @@ impl WaykCsePatcher {
         bundle.add_bundle_package(BundlePackageType::CseOptions, &processed_options_path);
 
         for bitness in &options.install_options().supported_architectures {
-            info!("Downloading artifacts zip for {} architecture...", bitness);
-            let artifacts_zip_path = working_dir.path().join(format!("Wayk_{}.zip", bitness));
-            download_latest_zip(&artifacts_zip_path, *bitness).with_context(|| {
-                format!(
-                    "Failed to download WaykNow executable for {} architecture",
-                    bitness
-                )
-            })?;
-            bundle.add_bundle_package(
-                BundlePackageType::WaykBinaries { bitness: *bitness },
-                &artifacts_zip_path,
-            );
-
-        if options.install_options().embed_msi.unwrap_or(true) {
+            if options.install_options().embed_msi.unwrap_or(true) {
                 info!("Downloading msi installer for {} architecture...", bitness);
                 let msi_path = working_dir
                     .path()


### PR DESCRIPTION
- CSE is now a win32 exe (subsystem:windows)
- CSE attaches to parent console, if it exists
- CSE invokes msiexec directly, no need to pack or invoke WaykAgent as a bootstrapper
- CSE invokes msiexec directly, no need to use a job object (fix Win7 compatibility)
- CSE Invokes msiexec directly, no need to quote MSI arguments
- Fix an argument to LzHttp_Get
- version bump to 0.1.5